### PR TITLE
Fix bug with special characters

### DIFF
--- a/mjml/tools.py
+++ b/mjml/tools.py
@@ -68,7 +68,7 @@ def _mjml_render_by_tcpserver(mjml_code):
         except socket.error:
             continue
         try:
-            s.sendall('{:09d}'.format(len(mjml_code)).encode('utf8'))
+            s.sendall('{:09d}'.format(len(mjml_code.decode('utf8'))).encode('utf8'))
             s.sendall(mjml_code)
             ok = force_str(socket_recvall(s, 1)) == '0'
             a = force_str(socket_recvall(s, 9))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -248,6 +248,29 @@ class TestMJMLTCPServer(TestCase):
                     {% endmjml %}
                 """)
 
+    def test_unicode(self):
+        with safe_change_mjml_settings():
+            mjml_settings.MJML_BACKEND_MODE = 'tcpserver'
+
+            html = self.render_tpl("""
+                {% mjml %}
+                    <mjml>
+                    <mj-body>
+                    <mj-container>
+                        <mj-section>
+                            <mj-column>
+                                <mj-text>©</mj-text>
+                            </mj-column>
+                        </mj-section>
+                    </mj-container>
+                    </mj-body>
+                    </mjml>
+                {% endmjml %}
+            """)
+            self.assertIn('<html ', html)
+            self.assertIn('<body', html)
+            self.assertIn(u'©', html)
+
     def test_large_tpl(self):
         with safe_change_mjml_settings():
             mjml_settings.MJML_BACKEND_MODE = 'tcpserver'


### PR DESCRIPTION
The Python part counts in utf8 and the JS part counts in unicode, so we have a count mismatch with multi-byte characters ( é © ).
That's why we decode them before counting so that we count the same things of both sides.