### PR TITLE
Add backend for HTTP servers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ before_install:
   - nvm use 8
 
 install:
-  - npm install mjml@$MJML_VERSION
+  - npm install mjml@$MJML_VERSION mjml-http-server
   - node_modules/.bin/mjml --version
   - pip install "Django$DJANGO_VERSION"
 

--- a/mjml/settings.py
+++ b/mjml/settings.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 
 MJML_BACKEND_MODE = getattr(settings, 'MJML_BACKEND_MODE', 'cmd')
-assert MJML_BACKEND_MODE in ('cmd', 'tcpserver')
+assert MJML_BACKEND_MODE in ('cmd', 'tcpserver', 'httpserver')
 
 # cmd backend mode configs
 MJML_EXEC_CMD = getattr(settings, 'MJML_EXEC_CMD', 'mjml')
@@ -12,3 +12,8 @@ MJML_TCPSERVERS = getattr(settings, 'MJML_TCPSERVERS', [('127.0.0.1', 28101)])
 assert isinstance(MJML_TCPSERVERS, (list, tuple))
 for t in MJML_TCPSERVERS:
     assert isinstance(t, (list, tuple)) and len(t) == 2 and isinstance(t[0], str) and isinstance(t[1], int)
+
+# http server mode configs
+MJML_HTTP_SERVER = getattr(settings, 'MJML_HTTP_SERVER', 'http://127.0.0.1:15500')
+MJML_HTTP_BASIC_AUTH_USERNAME = getattr(settings, 'MJML_HTTP_BASIC_AUTH_USERNAME', None)
+MJML_HTTP_BASIC_AUTH_PASSWORD = getattr(settings, 'MJML_HTTP_BASIC_AUTH_PASSWORD', None)

--- a/mjml/tools.py
+++ b/mjml/tools.py
@@ -106,7 +106,7 @@ def _mjml_render_by_http(mjml_code):
             mjml_settings.MJML_HTTP_BASIC_AUTH_PASSWORD,
         )
 
-    res = requests.post(url, auth=auth, data=mjml_code)
+    res = requests.post(url, auth=auth, data=mjml_code.encode('utf-8'))
     data = res.json()
     if res.status_code != 200:
         msg = (
@@ -117,7 +117,7 @@ def _mjml_render_by_http(mjml_code):
 
     if data['errors']:
         msg = 'MJML HTTP server returned errors after compilation data={}'.format(data)
-        raise RuntimeError('MJML  (via MJML HTTP server): {}'.format(data))
+        raise RuntimeError('MJML  (via MJML HTTP server): {}'.format(data['errors']))
 
     return force_str(data['html'])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ django>=1.8,<2.3; python_version >= "3"
 coverage==4.5.4
 six==1.12.0
 ndg-httpsclient>=0.5.1; python_version < "3"
+requests==2.22.0

--- a/tests/test_mjml_http.py
+++ b/tests/test_mjml_http.py
@@ -1,0 +1,97 @@
+import subprocess
+import time
+from unittest.mock import patch
+
+from requests.auth import HTTPBasicAuth
+from django.test import TestCase
+from mjml import settings as mjml_settings
+from mjml.tools import requests
+
+from .tests import safe_change_mjml_settings, render_tpl
+
+try:
+    from urllib.parse import urlparse
+except ModuleNotFoundError:
+    from urlparse import urlparse
+
+
+class TestMJMLHTTPServer(TestCase):
+    server_process = None
+    url = None
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestMJMLHTTPServer, cls).setUpClass()
+        parsed = urlparse(mjml_settings.MJML_HTTP_SERVER)
+        host, port = parsed.netloc.split(":")
+        cls.server_process = subprocess.Popen(
+            ["mjml-http-server", "--host={}".format(host), "--port={}".format(port)]
+        )
+        cls.url = "{}/v1/render".format(mjml_settings.MJML_HTTP_SERVER)
+        cls.settings_manager = safe_change_mjml_settings()
+        cls.settings_manager.__enter__()
+        mjml_settings.MJML_BACKEND_MODE = "httpserver"
+        time.sleep(1)
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestMJMLHTTPServer, cls).tearDownClass()
+        cls.server_process.terminate()
+        cls.settings_manager.__exit__(None, None, None)
+
+    def test_simple(self):
+        tpl = valid_tpl()
+        html = render_tpl(tpl)
+        self.assertIn("<html ", html)
+        self.assertIn("<body", html)
+        self.assertIn("Test button", html)
+
+    def test_raises_on_compilation_errors(self):
+        tpl = """
+            {% mjml %}
+            <mjml>
+                <mj-body>
+                    <mj-button>
+                </mj-body>
+            </mjml>
+            {% endmjml %}
+        """
+        with self.assertRaises(RuntimeError) as cm:
+            html = render_tpl(tpl)
+
+        self.assertIn(
+            (
+                "(mj-button) — mj-button cannot be used inside "
+                "mj-body, only inside: mj-attributes, mj-column, mj-hero"
+            ),
+            str(cm.exception),
+        )
+
+    @patch.object(requests, "post", wraps=requests.post)
+    def test_uses_basic_auth(self, post):
+        mjml_settings.MJML_HTTP_BASIC_AUTH_USERNAME = 'foo'
+        mjml_settings.MJML_HTTP_BASIC_AUTH_PASSWORD = 'bar'
+        tpl = valid_tpl()
+        render_tpl(tpl)
+        _, kwargs = post.call_args
+        expected_auth = HTTPBasicAuth('foo', 'bar')
+        self.assertEqual(kwargs["auth"], expected_auth)
+
+
+def valid_tpl():
+    return """
+        {% mjml %}
+          <mjml>
+            <mj-body>
+                <mj-container>
+                    <mj-section>
+                        <mj-column>
+                            <mj-button>Test button</mj-button>
+                        </mj-column>
+                    </mj-section>
+
+                </mj-container>
+            </mj-body>
+          </mjml>
+        {% endmjml %}
+    """

--- a/tests/test_mjml_http.py
+++ b/tests/test_mjml_http.py
@@ -77,6 +77,28 @@ class TestMJMLHTTPServer(TestCase):
         expected_auth = HTTPBasicAuth('foo', 'bar')
         self.assertEqual(kwargs["auth"], expected_auth)
 
+    @patch.object(requests, "post", wraps=requests.post)
+    def test_unicode(self, post):
+        tpl = '''
+        {% mjml %}
+          <mjml>
+            <mj-body>
+                <mj-container>
+                    <mj-section>
+                        <mj-column>
+                            <mj-text>
+                                🇪🇺EU-only
+                            </mj-text>
+                        </mj-column>
+                    </mj-section>
+                </mj-container>
+            </mj-body>
+          </mjml>
+        {% endmjml %}
+        '''
+        html = render_tpl(tpl)
+        self.assertIn("🇪🇺EU-only", html)
+
 
 def valid_tpl():
     return """
@@ -89,7 +111,6 @@ def valid_tpl():
                             <mj-button>Test button</mj-button>
                         </mj-column>
                     </mj-section>
-
                 </mj-container>
             </mj-body>
           </mjml>


### PR DESCRIPTION
The MJML team has released a HTTP API for integration with non NodeJS
apps at https://mjml.io/api.

I've built a self hosted alternative which should be compatible with the
API the MJML team has built (without baked in auth).
https://github.com/danihodovic/mjml-http-server

It should work with both auth and non-auth, although I have not tested
the auth version since https://mjml.io/api is currently invite only.