### PR TITLE
Simplify docker-compose.yml

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,12 +146,8 @@ Or you can use docker-compose::
     mjml-1:
       image: liminspace/mjml-tcpserver:latest
       restart: always
-      ports:
-        - "28101:28101"
 
     mjml-2:
       image: liminspace/mjml-tcpserver:latest
       restart: always
-      ports:
-        - "28102:28101"
 

--- a/README.rst
+++ b/README.rst
@@ -152,12 +152,6 @@ Or you can use docker-compose::
     mjml-2:
       image: liminspace/mjml-tcpserver:latest
       restart: always
-      environment:
-        HOST: "0.0.0.0"
-        PORT: "28102"
-        MJML_ARGS: "--mjml.minify=true --mjml.validationLevel=strict"
-      expose:
-        - "28102"
       ports:
-        - "28102:28102"
+        - "28102:28101"
 


### PR DESCRIPTION
I think you can remove some lines (in the first commit) for all use cases of the docker-compose version as the port inside the container doesn't matter outside the container. You just need to bind the container port to a different port outside

If the servers are going to be used from within the docker-compose file you can go a step further and not bind the ports at all as the servers will still be accessible from other services in the same docker-compose file, because the ports were EXPOSE'd in the DockerFile