### PR TITLE
Remove settings type check in authentication tuple to prevent from failing in LazySettings

### DIFF
--- a/mjml/settings.py
+++ b/mjml/settings.py
@@ -27,4 +27,4 @@ for t in MJML_HTTPSERVERS:
         http_auth = t['HTTP_AUTH']
         assert isinstance(http_auth, (type(None), list, tuple))
         if http_auth is not None:
-            assert len(http_auth) == 2 and isinstance(http_auth[0], str) and isinstance(http_auth[1], str)
+            assert len(http_auth) == 2


### PR DESCRIPTION
Currently, django-mjml checks for the proper type (str) in the auth tuple in HTTP_SERVERS. Sadly this does not work in a LazySettings environment (`django-configurations`). This PR removes the assertion of type for the authentication tuple to make this package compatible with `django-configurations`.

Example:

```python
MJML_BACKEND_MODE = 'httpserver'
MJML_APPLICATION_ID = values.SecretValue()
MJML_SECRET_KEY = values.SecretValue()
MJML_HTTPSERVERS = [
        {
            'URL': 'https://api.mjml.io/v1/render',  # official MJML API
            'HTTP_AUTH': (MJML_APPLICATION_ID, MJML_SECRET_KEY), # won't evaluate to type str directly
        },
]
```