### PR TITLE
fix: add requests to setup install_requires.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     platforms=['OS Independent'],
     install_requires=[
         'django>=1.8,<3.1',
+        'requests'
     ],
     keywords=[
         'django', 'mjml', 'django-mjml', 'email', 'layout', 'template', 'templatetag',


### PR DESCRIPTION
The package `requests` is not declared in install_requires in setup.py.

it would run into an `ImportError` if user didn't have `requests`.