### PR TITLE
Upgrade Django to 4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
       NODE_VER: 14
     strategy:
       matrix:
-        django-ltver: [1.12, 2.1, 2.2, 2.3, 3.1, 3.2, 3.3]
+        django-ltver: [1.12, 2.1, 2.2, 2.3, 3.1, 3.2, 3.3, 4.0]
         mjml-ver: [4.4.0, 4.5.1, 4.6.3, 4.7.1, 4.8.2, 4.9.3, 4.10.1]
       fail-fast: false
     steps:
@@ -86,7 +86,7 @@ jobs:
       NODE_VER: 14
     strategy:
       matrix:
-        django-ltver: [1.12, 2.1, 2.2, 2.3, 3.1, 3.2, 3.3]
+        django-ltver: [1.12, 2.1, 2.2, 2.3, 3.1, 3.2, 3.3, 4.0]
         mjml-ver: [4.4.0, 4.5.1, 4.6.3, 4.7.1, 4.8.2, 4.9.3, 4.10.1]
       fail-fast: false
     steps:
@@ -122,7 +122,7 @@ jobs:
       NODE_VER: 14
     strategy:
       matrix:
-        django-ltver: [2.3, 3.1, 3.2, 3.3]
+        django-ltver: [2.3, 3.1, 3.2, 3.3, 4.0]
         mjml-ver: [4.4.0, 4.5.1, 4.6.3, 4.7.1, 4.8.2, 4.9.3, 4.10.1]
       fail-fast: false
     steps:
@@ -158,7 +158,7 @@ jobs:
       NODE_VER: 14
     strategy:
       matrix:
-        django-ltver: [2.3, 3.1, 3.2, 3.3]
+        django-ltver: [2.3, 3.1, 3.2, 3.3, 4.0]
         mjml-ver: [4.4.0, 4.5.1, 4.6.3, 4.7.1, 4.8.2, 4.9.3, 4.10.1]
       fail-fast: false
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,7 +122,7 @@ jobs:
       NODE_VER: 14
     strategy:
       matrix:
-        django-ltver: [2.3, 3.1, 3.2, 3.3, 4.0]
+        django-ltver: [2.3, 3.1, 3.2, 3.3, 4.0, 4.1]
         mjml-ver: [4.4.0, 4.5.1, 4.6.3, 4.7.1, 4.8.2, 4.9.3, 4.10.1]
       fail-fast: false
     steps:
@@ -158,7 +158,7 @@ jobs:
       NODE_VER: 14
     strategy:
       matrix:
-        django-ltver: [2.3, 3.1, 3.2, 3.3, 4.0]
+        django-ltver: [2.3, 3.1, 3.2, 3.3, 4.0, 4.1]
         mjml-ver: [4.4.0, 4.5.1, 4.6.3, 4.7.1, 4.8.2, 4.9.3, 4.10.1]
       fail-fast: false
     steps:

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Installation
 Requirements:
 ^^^^^^^^^^^^^
 
-* ``Django`` from 1.8 to 3.2
+* ``Django`` from 1.8 to 4.0
 * ``requests`` from 2.20.0 (only if you are going to use API HTTP-server for rendering)
 * ``mjml`` from 2.3 to 4.10.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ twine==1.15.0; python_version < "3"
 twine==3.4.1; python_version >= "3"
 coverage==5.5
 django<1.12; python_version < "3"
-django>=1.8,<3.3; python_version >= "3"
+django>=1.8,<4.1; python_version >= "3"
 six==1.15.0; python_version < "3"
 ndg-httpsclient>=0.5.1; python_version < "3"
 mock<4.1; python_version < "3"

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     zip_safe=False,  # because include static
     platforms=['OS Independent'],
     install_requires=[
-        'django >=1.8,<3.3',
+        'django >=1.8,<4.1',
     ],
     extras_require={
         'requests': [


### PR DESCRIPTION
This PR allows django-mjml to work with Django 4.0 