### PR TITLE
Remove deprecated mj-container from example (update for MJML v4)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,15 +61,13 @@ Load ``mjml`` in your django template and use ``mjml`` tag that will compile MJM
 
   {% mjml %}
       <mjml>
-      <mj-body>
-      <mj-container>
-          <mj-section>
-              <mj-column>
-                  <mj-text>Hello world!</mj-text>
-              </mj-column>
-          </mj-section>
-      </mj-container>
-      </mj-body>
+          <mj-body>
+              <mj-section>
+                  <mj-column>
+                      <mj-text>Hello world!</mj-text>
+                  </mj-column>
+              </mj-section>
+          </mj-body>
       </mjml>
   {% endmjml %}
 


### PR DESCRIPTION
`mj-container` is deprecated in MJML v4. Using it throws a `mj-migrate` warning. It's better DX to have the example in the readme work without modifications.