### PR TITLE
Add option to set any requests authorization backend

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,6 +128,9 @@ httpserver mode
 This mode is faster than ``cmd`` and a bit slower than ``tcpserver``, but you can use official MJML API https://mjml.io/api
 or run your own HTTP-server (for example https://github.com/danihodovic/mjml-server) to render templates.
 
+You can use any Authentication backend supported by requests (or provide your own). 
+See https://requests.readthedocs.io/en/latest/user/authentication/ for details.
+
 Configure your Django::
 
   MJML_BACKEND_MODE = 'httpserver'

--- a/mjml/settings.py
+++ b/mjml/settings.py
@@ -1,4 +1,8 @@
 from django.conf import settings
+try:
+    from requests.auth import AuthBase
+except ImportError:
+    AuthBase = None
 
 MJML_BACKEND_MODE = getattr(settings, 'MJML_BACKEND_MODE', 'cmd')
 assert MJML_BACKEND_MODE in {'cmd', 'tcpserver', 'httpserver'}
@@ -24,6 +28,10 @@ for t in MJML_HTTPSERVERS:
     assert 'URL' in t and isinstance(t['URL'], str)
     if 'HTTP_AUTH' in t:
         http_auth = t['HTTP_AUTH']
-        assert isinstance(http_auth, (type(None), list, tuple))
-        if http_auth is not None:
+        if AuthBase:
+            assert isinstance(http_auth, (type(None), list, tuple, AuthBase))
+        else:  
+            assert isinstance(http_auth, (type(None), list, tuple))
+
+        if isinstance(http_auth, (list, tuple)):
             assert len(http_auth) == 2 and isinstance(http_auth[0], str) and isinstance(http_auth[1], str)

--- a/mjml/tools.py
+++ b/mjml/tools.py
@@ -109,7 +109,12 @@ def _mjml_render_by_httpserver(mjml_code: str) -> str:
     timeouts = 0
     for server_conf in servers:
         http_auth = server_conf.get('HTTP_AUTH')
-        auth = requests.auth.HTTPBasicAuth(*http_auth) if http_auth else None
+
+        auth = (
+            http_auth
+            if isinstance(http_auth, (type(None), requests.auth.AuthBase))
+            else requests.auth.HTTPBasicAuth(*http_auth)
+        )
 
         try:
             response = requests.post(


### PR DESCRIPTION
Considering HTTPBasicAuth is what [requests will use if you pass a tuple](https://requests.readthedocs.io/en/latest/user/authentication/#basic-authentication), we could probably simplify a bit my changes in `_mjml_render_by_httpserver`.

But otherwise, that’s the only changes I would recommend to your lib, and then anyone can just take care of whatever auth they want to use.