### PR TITLE
Remove DeprecationWarning on default_app_config for django 3.2+

### DIFF
--- a/mjml/__init__.py
+++ b/mjml/__init__.py
@@ -1,3 +1,7 @@
+import django
+
 __version__ = '1.1'
 
-default_app_config = 'mjml.apps.MJMLConfig'
+if django.VERSION < (3, 2):
+    default_app_config = 'mjml.apps.MJMLConfig'
+


### PR DESCRIPTION
I propose a slight change for removing DeprecationWarning. 

Django 3.2+ does not need to default_app_config and raise a DeprecationWarning when the app uses it.

