### PR TITLE
Add optional random server selection for TCP and HTTP backends

### DIFF
--- a/mjml/settings.py
+++ b/mjml/settings.py
@@ -9,6 +9,7 @@ MJML_CHECK_CMD_ON_STARTUP = getattr(settings, 'MJML_CHECK_CMD_ON_STARTUP', True)
 
 # tcpserver backend mode configs
 MJML_TCPSERVERS = getattr(settings, 'MJML_TCPSERVERS', [('127.0.0.1', 28101)])
+MJML_TCPSERVERS_USE_RANDOM = getattr(settings, 'MJML_TCPSERVERS_RANDOM', True)
 assert isinstance(MJML_TCPSERVERS, (list, tuple))
 for t in MJML_TCPSERVERS:
     assert isinstance(t, (list, tuple)) and len(t) == 2 and isinstance(t[0], str) and isinstance(t[1], int)
@@ -18,6 +19,7 @@ MJML_HTTPSERVERS = getattr(settings, 'MJML_HTTPSERVERS', [{
     'URL': 'https://api.mjml.io/v1/render',
     'HTTP_AUTH': None,  # None (default) or ('login', 'password')
 }])
+MJML_HTTPSERVERS_USE_RANDOM = getattr(settings, 'MJML_HTTPSERVERS_RANDOM', True)
 assert isinstance(MJML_HTTPSERVERS, (list, tuple))
 for t in MJML_HTTPSERVERS:
     assert isinstance(t, dict)

--- a/mjml/tools.py
+++ b/mjml/tools.py
@@ -59,7 +59,7 @@ def socket_recvall(sock: socket.socket, n: int) -> Optional[bytes]:
 def _mjml_render_by_tcpserver(mjml_code: str) -> str:
     if len(mjml_settings.MJML_TCPSERVERS) > 1:
         servers = list(mjml_settings.MJML_TCPSERVERS)[:]
-        if mjml_settings.MJML_TCPSERVERS_USE_RANDOM:
+        if mjml_settings.MJML_TCPSERVERS_USE_RANDOM is True:
             random.shuffle(servers)
     else:
         servers = mjml_settings.MJML_TCPSERVERS
@@ -103,7 +103,7 @@ def _mjml_render_by_httpserver(mjml_code: str) -> str:
 
     if len(mjml_settings.MJML_HTTPSERVERS) > 1:
         servers = list(mjml_settings.MJML_HTTPSERVERS)[:]
-        if mjml_settings.MJML_HTTPSERVERS_USE_RANDOM:
+        if mjml_settings.MJML_HTTPSERVERS_USE_RANDOM is True:
             random.shuffle(servers)
     else:
         servers = mjml_settings.MJML_HTTPSERVERS

--- a/mjml/tools.py
+++ b/mjml/tools.py
@@ -59,7 +59,8 @@ def socket_recvall(sock: socket.socket, n: int) -> Optional[bytes]:
 def _mjml_render_by_tcpserver(mjml_code: str) -> str:
     if len(mjml_settings.MJML_TCPSERVERS) > 1:
         servers = list(mjml_settings.MJML_TCPSERVERS)[:]
-        random.shuffle(servers)
+        if mjml_settings.MJML_TCPSERVERS_USE_RANDOM:
+            random.shuffle(servers)
     else:
         servers = mjml_settings.MJML_TCPSERVERS
     mjml_code_data = force_bytes(mjml_code)
@@ -102,7 +103,8 @@ def _mjml_render_by_httpserver(mjml_code: str) -> str:
 
     if len(mjml_settings.MJML_HTTPSERVERS) > 1:
         servers = list(mjml_settings.MJML_HTTPSERVERS)[:]
-        random.shuffle(servers)
+        if mjml_settings.MJML_HTTPSERVERS_USE_RANDOM:
+            random.shuffle(servers)
     else:
         servers = mjml_settings.MJML_HTTPSERVERS
 


### PR DESCRIPTION
Introduced a new setting **MJML_TCPSERVERS_RANDOM** and **MJML_HTTPSERVERS_RANDOM** for server selection, allowing random server selection to be toggled. This makes it possible to either use the servers in order or randomly.

* Both settings default to True, enabling random selection by default, but can be set to False to maintain a fixed order of servers.

* Refactored the `mjml/tools.py` file to shuffle the servers list based on the new settings for both TCP and HTTP backends.
